### PR TITLE
Feat/logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Clinic Pipeline
+
+A web scraping pipeline for extracting patient data from a clinic management system.
+
+## Features
+
+- **Web Scraping**: Automated data extraction using Selenium WebDriver
+- **Logging**: Comprehensive logging system with file rotation
+- **Data Processing**: Clean and structure extracted patient data
+- **Configuration**: Environment-based configuration management
+
+## Project Structure
+
+```
+clinic-pipeline/
+├── src/
+│   ├── main.py           # Main application entry point
+│   ├── scraper.py        # Web scraping functionality
+│   ├── utils.py          # Utility functions for data processing
+│   └── logger_config.py  # Logging configuration
+├── logs/                 # Log files directory
+├── samples/              # Sample data files
+├── pyproject.toml        # Project dependencies and configuration
+└── LOGGING.md           # Logging documentation
+```
+
+## Setup
+
+1. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   # or if using uv:
+   uv sync
+   ```
+
+2. **Configure environment**:
+   Create a `.env` file with your credentials:
+   ```
+   URL=your_clinic_url
+   USERNAME_=your_username
+   PASSWORD_=your_password
+   ```
+
+3. **Install ChromeDriver**:
+   Make sure you have Chrome and ChromeDriver installed for Selenium automation.
+
+## Usage
+
+Run the main scraper:
+
+```bash
+python src/main.py
+```
+
+## Logging
+
+The application uses a structured logging system that outputs to both console and rotating log files. See [LOGGING.md](LOGGING.md) for detailed information about the logging configuration.
+
+## Dependencies
+
+- **selenium**: Web automation
+- **python-dotenv**: Environment configuration
+- **webdriver-manager**: ChromeDriver management
+
+## Output
+
+Extracted patient data is saved as JSON files with timestamps:
+- Format: `patient_data_YYYYMMDD_HHMMSS.json`
+- Location: Project root directory

--- a/src/logger_config.py
+++ b/src/logger_config.py
@@ -1,0 +1,72 @@
+import logging
+import logging.handlers
+import os
+from datetime import datetime
+
+
+def setup_logger(
+    name: str = "clinic_pipeline", level: int = logging.INFO
+) -> logging.Logger:
+    """
+    Set up a logger with file and console handlers.
+
+    Args:
+        name: Logger name
+        level: Logging level (default: INFO)
+
+    Returns:
+        Configured logger instance
+    """
+    logger = logging.getLogger(name)
+
+    # Prevent adding handlers multiple times
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(level)
+
+    # Create logs directory if it doesn't exist
+    logs_dir = "logs"
+    if not os.path.exists(logs_dir):
+        os.makedirs(logs_dir)
+
+    # Create formatter
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # File handler with rotation
+    timestamp = datetime.now().strftime("%Y%m%d")
+    log_filename = os.path.join(logs_dir, f"clinic_pipeline_{timestamp}.log")
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_filename,
+        maxBytes=10 * 1024 * 1024,  # 10MB
+        backupCount=5,
+    )
+    file_handler.setLevel(level)
+    file_handler.setFormatter(formatter)
+
+    # Console handler
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(level)
+    console_handler.setFormatter(formatter)
+
+    # Add handlers to logger
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+
+    return logger
+
+
+def get_logger(name: str = "clinic_pipeline") -> logging.Logger:
+    """
+    Get an existing logger or create a new one.
+
+    Args:
+        name: Logger name
+
+    Returns:
+        Logger instance
+    """
+    return logging.getLogger(name)

--- a/src/main.py
+++ b/src/main.py
@@ -2,9 +2,13 @@ import os
 from scraper import Scraper
 from dotenv import load_dotenv
 from utils import save_data_to_file
+from logger_config import setup_logger
 
 
 def main():
+    # Setup logger
+    logger = setup_logger()
+
     load_dotenv()
 
     url = os.getenv("URL")
@@ -14,15 +18,15 @@ def main():
     with Scraper(
         url=url, username=username, password=password, headless=True
     ) as scraper:
-        print("Scraper initialized...")
+        logger.info("Scraper initialized...")
 
         # Step 1: Login
         if scraper.login():
             patient_data = scraper.extract_patient_data()
             save_data_to_file(patient_data)
-            
+
         else:
-            print("Login failed. Please check your credentials and URL.")
+            logger.error("Login failed. Please check your credentials and URL.")
             scraper.take_screenshot("images/login_failed.png")
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import re
+from logger_config import get_logger
 
 
 def clean_date_hour(date_hour_text):
@@ -78,6 +79,8 @@ def save_data_to_file(patient_data):
     import json
     from datetime import datetime
 
+    logger = get_logger()
+
     cleaned_data = clean_patient_data(patient_data)
 
     filename = f"patient_data_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
@@ -85,6 +88,6 @@ def save_data_to_file(patient_data):
     try:
         with open(filename, "w", encoding="utf-8") as f:
             json.dump(cleaned_data, f, indent=2, ensure_ascii=False)
-        print(f"Patient data saved to {filename}")
+        logger.info(f"Patient data saved to {filename}")
     except Exception as e:
-        print(f"Error saving data to file: {e}")
+        logger.error(f"Error saving data to file: {e}")


### PR DESCRIPTION
This pull request introduces a logging system to replace print statements with structured logging across the application. It also updates the `README.md` file to provide documentation for the clinic pipeline project. The most significant changes include adding a logging configuration module, integrating logging into the main application, and replacing print statements with logger calls in the `Scraper` class.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R69): Added comprehensive documentation for the clinic pipeline project, including features, project structure, setup instructions, usage, logging details, dependencies, and output format.

### Logging System Implementation:
* [`src/logger_config.py`](diffhunk://#diff-94f6f0c7f230fb7b2d70070cd1432d0fd88f5b2b8a4c7b671d6f2ef3798eb4a7R1-R72): Added a new module to set up logging with file rotation and console output, including methods for logger retrieval and configuration.

### Integration of Logging in Main Application:
* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R5-R11): Integrated the logging system by setting up a logger in the `main` function and replacing print statements with logger calls for key application events. [[1]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R5-R11) [[2]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L17-R29)

### Integration of Logging in `Scraper` Class:
* [`src/scraper.py`](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eR8): Replaced all print statements with logger calls for error handling, debugging, and informational messages. Added logger initialization in the `Scraper` class constructor and used structured logging for methods like `login`, `scrape_data`, `navigate_to`, and `extract_patient_data`. [[1]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eR8) [[2]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eR40) [[3]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL59-R64) [[4]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL102-R113) [[5]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL124-R124) [[6]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL135-R135) [[7]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL144-R144) [[8]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL157-R157) [[9]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL170-R170) [[10]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL181-R193) [[11]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL210-R218) [[12]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL235-R241) [[13]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL255-R281) [[14]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eR291-R300) [[15]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL313-R328) [[16]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL338-R345) [[17]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL389-R394) [[18]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL404-R412) [[19]](diffhunk://#diff-0e4337d858599ae81588070897d6d27bb45de76e0e4dd92ad2ae2e55f575ca0eL418-R427)